### PR TITLE
feat: add support for GCE ARM instances

### DIFF
--- a/script/yaki
+++ b/script/yaki
@@ -109,7 +109,7 @@ fatal() { echo "[ERROR] $@" >&2; exit 1; }
 setup_arch() {
     case ${ARCH:=$(uname -m)} in
         amd64|x86_64) ARCH=amd64 ;;
-        arm64) ARCH=arm64 ;;
+        arm64|aarch64) ARCH=arm64 ;;
         *) fatal "unsupported architecture ${ARCH}" ;;
     esac
     SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-${ARCH}


### PR DESCRIPTION
This is necessary to allow the script to run correctly on Google Compute Engine (GCE) ARM instances.

`uname -a
Linux eph-fra-gcp-infra-arm-fra-1-mz1h 6.14.0-1017-gcp #18~24.04.1-Ubuntu SMP Tue Sep 23 17:43:54 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux`