### PR TITLE
fix: modified cluster version in setup.env

### DIFF
--- a/guides/setup.env
+++ b/guides/setup.env
@@ -25,7 +25,7 @@ export WORKER_IF=eth0
 # kubernetes
 export CLUSTER_NAME=demo
 export CLUSTER_DOMAIN=labs.clastix.io
-export CLUSTER_VERSION=1.30.2
+export CLUSTER_VERSION=1.36.1
 export POD_CIDR=10.36.0.0/16
 export SVC_CIDR=10.96.0.0/16
 export DNS_SERVICE=10.96.0.10


### PR DESCRIPTION
Updated `CLUSTER_VERSION` from `1.30.2` to `1.36.1`  in `guides/setup.env` file.