### PR TITLE
update: align ansible playbooks versions of components

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -6,4 +6,4 @@ remote_user = clastix
 host_key_checking = False
 stdout_callback=debug
 stderr_callback=debug
-
+inject_facts_as_vars = True

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -2,8 +2,8 @@
 # local machine
 ansible_user: clastix
 arch: amd64
-helm_version: v3.15.2
-flux_version: v2.4.0
+helm_version: v4.2.2
+flux_version: v2.9.0
 
 # http(s) proxy settings
 use_http_proxy: false
@@ -16,15 +16,15 @@ proxy_env:
   no_proxy: "{{ no_proxy }}"
 
 # etcd
-etcd_version: v3.5.16
+etcd_version: v3.6.3
 etcd_cert_dir: /etc/kubernetes/pki/etcd
 etcd_data_dir: /var/lib/etcd/data
 etcd_client_port: 2379
 etcd_peer_port: 2380
-etcd_metrics_port: 2381   
+etcd_metrics_port: 2381
 
 # kubernetes
-kubernetes_version: v1.32.4
+kubernetes_version: v1.36.2
 kubernetes_cert_dir: /etc/kubernetes/pki
 cluster_name: kamaji
 cluster_name_aliases: [] # List of aliases for the cluster name
@@ -39,15 +39,15 @@ control_plane_port: 6443
 control_plane_lb: false # Set to true if you want to use an embedded load balancer for the control plane
 control_plane_lb_port: 8443 # The port on which the internal control plane load balancer listens
 control_plane_interface: eth0
-coredns_version: v1.11.3
+coredns_version: v1.14.2
 calico_version: v3.29.1
-clusterctl_version: v1.9.5
+clusterctl_version: v1.13.3
 
 # container runtime
-containerd_version: v1.7.24
-runc_version: v1.2.6
-cni_version: v1.6.2
-crictl_version: v1.32.0
+containerd_version: v2.3.2
+runc_version: v1.4.3
+cni_version: v1.9.1
+crictl_version: v1.36.0
 bin_dir: /usr/local/bin
 sbin_dir: /usr/local/sbin
 


### PR DESCRIPTION
This pull request updates several core dependency versions and configuration settings for the Ansible-based Kubernetes deployment, ensuring the stack uses the latest stable releases and improves configuration consistency. 

Dependency version upgrades:

* Updated major component versions in `ansible/inventory/group_vars/all.yml`:
  - `kubernetes_version` to v1.36.2, `etcd_version` to v3.6.3, `coredns_version` to v1.14.2, and `clusterctl_version` to v1.13.3. [[1]](diffhunk://#diff-a9e26f83a4a9763bd4261ca4b7d94354ff85fb63301d701c683420cdfded7c0bL19-R27) [[2]](diffhunk://#diff-a9e26f83a4a9763bd4261ca4b7d94354ff85fb63301d701c683420cdfded7c0bL37-R50)
  - Upgraded container runtime tools: `containerd_version` to v2.3.2, `runc_version` to v1.4.3, `cni_version` to v1.9.1, and `crictl_version` to v1.36.0.
  - Updated `helm_version` to v4.2.2 and `flux_version` to v2.9.0.

Configuration changes:

* Enabled `inject_facts_as_vars` in `ansible/ansible.cfg` to improve variable injection behavior.