### PR TITLE
feat(docs): added KubeVIP installation path

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -6,4 +6,4 @@ remote_user = clastix
 host_key_checking = False
 stdout_callback=debug
 stderr_callback=debug
-
+inject_facts_as_vars = True

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -2,8 +2,8 @@
 # local machine
 ansible_user: clastix
 arch: amd64
-helm_version: v3.15.2
-flux_version: v2.4.0
+helm_version: v4.2.2
+flux_version: v2.9.0
 
 # http(s) proxy settings
 use_http_proxy: false
@@ -16,15 +16,15 @@ proxy_env:
   no_proxy: "{{ no_proxy }}"
 
 # etcd
-etcd_version: v3.5.16
+etcd_version: v3.6.3
 etcd_cert_dir: /etc/kubernetes/pki/etcd
 etcd_data_dir: /var/lib/etcd/data
 etcd_client_port: 2379
 etcd_peer_port: 2380
-etcd_metrics_port: 2381   
+etcd_metrics_port: 2381
 
 # kubernetes
-kubernetes_version: v1.32.4
+kubernetes_version: v1.36.2
 kubernetes_cert_dir: /etc/kubernetes/pki
 cluster_name: kamaji
 cluster_name_aliases: [] # List of aliases for the cluster name
@@ -39,15 +39,15 @@ control_plane_port: 6443
 control_plane_lb: false # Set to true if you want to use an embedded load balancer for the control plane
 control_plane_lb_port: 8443 # The port on which the internal control plane load balancer listens
 control_plane_interface: eth0
-coredns_version: v1.11.3
+coredns_version: v1.14.2
 calico_version: v3.29.1
-clusterctl_version: v1.9.5
+clusterctl_version: v1.13.3
 
 # container runtime
-containerd_version: v1.7.24
-runc_version: v1.2.6
-cni_version: v1.6.2
-crictl_version: v1.32.0
+containerd_version: v2.3.2
+runc_version: v1.4.3
+cni_version: v1.9.1
+crictl_version: v1.36.0
 bin_dir: /usr/local/bin
 sbin_dir: /usr/local/sbin
 


### PR DESCRIPTION
This pull request significantly expands the `guides/advanced.md` documentation to provide a comprehensive, side-by-side guide for setting up a high availability Kubernetes cluster using either `keepalived` or `kube-vip` as the control plane virtual IP solution. The guide is reorganized to clearly present both approaches, their pros and cons, and step-by-step instructions for each path, including setup, bootstrap, and cleanup procedures.

**Major documentation enhancements:**

* Added a detailed comparison and explanation of the two supported load balancing strategies for the Kubernetes control plane virtual IP: `keepalived` and `kube-vip`, including a summary table and pros/cons for each. [[1]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R4-R5) [[2]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R231-R270)
* Refactored the guide's structure to introduce a "fork" in the procedure, allowing users to choose between Path A (`keepalived`) and Path B (`kube-vip`), with clear navigation and resumption points for common steps. [[1]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R28-R39) [[2]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778L447-R729)

**Expanded instructions for both approaches:**

* For `keepalived`:
  - Clarified and corrected all references from `kubelived` to `keepalived`.
  - Expanded setup, initialization, joining, and cleanup steps for both control plane and worker nodes. [[1]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R231-R270) [[2]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778L272-R320) [[3]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778L321) [[4]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R467-R468) [[5]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R780-R803)

* For `kube-vip`:
  - Added a full, step-by-step path covering manual VIP assignment during bootstrap, static pod manifest generation, distribution, and cleanup, including relevant warnings and troubleshooting tips.

**Additional improvements:**

* Updated requirements to note that `curl` and `jq` are needed on the bootstrap machine for the `kube-vip` path.
* Clarified cleanup instructions for both approaches, ensuring no virtual IPs are left behind after reset.


**References:**  
[[1]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R4-R5) [[2]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R28-R39) [[3]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R231-R270) [[4]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778L272-R320) [[5]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778L321) [[6]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R467-R468) [[7]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778L447-R729) [[8]](diffhunk://#diff-9c044372e15915752aef91099678f07cc5868701a5f75c62988fc37981557778R780-R803)